### PR TITLE
Login now validates user ID

### DIFF
--- a/odyssey/app/controllers/sessions_controller.rb
+++ b/odyssey/app/controllers/sessions_controller.rb
@@ -2,7 +2,20 @@ class SessionsController < ApplicationController
   def new
   end
   def create
-    #render 'pages/home/home1'
-    redirect_to '/home/home1'
+    # Find the user by their user ID
+    user = User.find_by(user_id: params[:session][:user_id])
+    # TODO: Will need to actually authenticate the user, once the Users
+    #  controller is finished.
+    #if user && user.authenticate(params[:session][:password])
+    
+    # If the user exists, send them to the home1 page
+    if user
+      redirect_to '/home/home1'
+    else
+      # Otherwise, keep them on the login page.
+      # TODO: Figure out why the flash message doesn't work
+      flash.now[:danger] = 'Invalid user ID/password combination'
+      render 'new'
+    end
   end
 end

--- a/odyssey/app/views/sessions/new.html.erb
+++ b/odyssey/app/views/sessions/new.html.erb
@@ -15,8 +15,8 @@
                 <br>
                     <%= form_for(:session, url: login_path) do |f| %>
               
-                    <%= f.label :email %>
-                    <%= f.email_field :email, class: 'form-control' %>
+                    <%= f.label :user_id %>
+                    <%= f.text_field :user_id, class: 'form-control' %>
               
                     <%= f.label :password %>
                     <%= f.password_field :password, class: 'form-control' %>

--- a/odyssey/db/seeds.rb
+++ b/odyssey/db/seeds.rb
@@ -53,3 +53,13 @@ end
               created_at:             Time.zone.now,
               updated_at:             Time.zone.now,
               status:                 status)
+
+# Create a blank admin user, so that by default, while developing, login will still work
+User.create!(user_id: "",
+              user_name: "Test Admin",
+              user_email: "foo@foo.com",
+              user_password_digest: "",
+              permission_level: 2,
+              created_at: Time.zone.now,
+              updated_at: Time.zone.now,
+              status: status)


### PR DESCRIPTION
If a valid user ID is given, then the Sessions controller will redirect the user to /home/home1.
If an invalid user ID is given, then the user will be kept at the login page.
A blank userID/password admin user was added to the seed, so that the login page will function normally during development.
Note: The database will have to be seeded to add that user. `bundle exec rake db:seed`