### PR TITLE
Fixed session controller routing

### DIFF
--- a/odyssey/app/controllers/sessions_controller.rb
+++ b/odyssey/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       # Store the user_id in the session
       log_in user
-      redirect_to '/home/home1'
+      redirect_to pickups_path
     else
       # Otherwise, keep them on the login page.
       flash.now[:danger] = 'Invalid user ID/password combination'

--- a/odyssey/app/controllers/sessions_controller.rb
+++ b/odyssey/app/controllers/sessions_controller.rb
@@ -2,7 +2,12 @@ class SessionsController < ApplicationController
   # Logging out is only allowed if the user is actually logged in
   before_action :logged_in, only: [:destroy]
   
+  # If the user is already logged in, they should be routed to the homepage.
+  #  Otherwise, render the login screen
   def new
+    if logged_in?
+      redirect_to pickups_path
+    end
   end
   
   # Create will log the user in, or display a message if the login attempt

--- a/odyssey/app/helpers/sessions_helper.rb
+++ b/odyssey/app/helpers/sessions_helper.rb
@@ -20,14 +20,14 @@ module SessionsHelper
   def is_admin
     if !is_admin?
       flash[:danger] = "You are not an admin"
-      redirect_to '/home/home1'
+      redirect_to pickups_path
     end
   end
   
   def admin_or_standard
     if !is_admin? && !is_standard?
       flash[:danger] = "You do not have permission to view this page"
-      redirect_to '/home/home1'
+      redirect_to pickups_path
     end
   end
   


### PR DESCRIPTION
Session controller now redirects from `/login` to the homepage, if the user is already logged in.
The homepage is now `/pickups`, not `/home/home1`